### PR TITLE
Fix default parameter from being a list to None.

### DIFF
--- a/solathon/transaction.py
+++ b/solathon/transaction.py
@@ -271,7 +271,10 @@ class Transaction:
     def serialize_message(self) -> bytes:
         return self.compile_transaction().serialize()
 
-    def sign(self, signers: Optional[list[PublicKey | Keypair]] = []) -> None:
+    def sign(self, signers: Optional[list[PublicKey | Keypair]] = None) -> None:
+        if signers is None:
+            signers = []
+
         signers.insert(0, self.sender)  # Inserting sender to first index
 
         def to_public_key(signer: PublicKey | Keypair) -> Keypair | PublicKey:


### PR DESCRIPTION
I believe this is an anti pattern in Python (#10) https://towardsdatascience.com/18-common-python-anti-patterns-i-wish-i-had-known-before-44d983805f0f

Best to default to None and check for None in function body when defaulting to mutable objects.
