### PR TITLE
fix client.get_block_height()

### DIFF
--- a/solathon/client.py
+++ b/solathon/client.py
@@ -614,10 +614,10 @@ class Client:
             if "error" in res:
                 raise RPCRequestError(f"Failed to fetch data from RPC endpoint. Error {res['error']['code']}: {res['error']['message']}")
             
-            if isinstance(res['result'], dict) or isinstance(res['result'], list) or isinstance(res['result'], str) or res['result'] == None:
+            if isinstance(res['result'], dict) or isinstance(res['result'], list) or isinstance(res['result'], str) or isinstance(res['result'], int) or res['result'] == None:
                 return res['result']
             else:
-                raise RPCRequestError(f"Invalid response from RPC endpoint. Expected types dict | list | str, got {type(res['result']).__name__}")
+                raise RPCRequestError(f"Invalid response from RPC endpoint. Expected types dict | list | str | int, got {type(res['result']).__name__}")
             
         return res
 


### PR DESCRIPTION
```
>>> from solathon import Client, Keypair
>>> client = Client("https://api.devnet.solana.com")
>>> client.get_block_height()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/.local/lib/python3.10/site-packages/solathon/client.py", line 115, in get_block_height
    return self.build_and_send_request("getBlockHeight", [commitment])
  File "/home/ubuntu/.local/lib/python3.10/site-packages/solathon/client.py", line 620, in build_and_send_request
    raise RPCRequestError(f"Invalid response from RPC endpoint. Expected types dict | list | str, got {type(res['result']).__name__}")
solathon.utils.RPCRequestError: Invalid response from RPC endpoint. Expected types dict | list | str, got int
```

after fix:
```
>>> from solathon import Client, Keypair
>>> client = Client("https://api.devnet.solana.com")
>>> client.get_block_height()
275785420

```