### PR TITLE
fixed from_file() method, it was passing wrong value to from_private_key()

### DIFF
--- a/solathon/keypair.py
+++ b/solathon/keypair.py
@@ -66,6 +66,6 @@ class Keypair:
             data = json.load(f)
 
         private_key_bytes = bytes(data[:32])
-        private_key = base58.b58encode(private_key_bytes)
+        private_key = base58.b58encode(private_key_bytes).decode('utf-8')
         keypair = Keypair.from_private_key(private_key)
         return keypair


### PR DESCRIPTION
I was noticing the wrong public key was being returned when trying to load a local keypair file. Just had to add decode() method to the byte literal conversion on line 69.