### PR TITLE
🐛 fix: correct method name typo in create_transfer function

### DIFF
--- a/solathon/solana_pay/create_transfer.py
+++ b/solathon/solana_pay/create_transfer.py
@@ -106,11 +106,11 @@ def create_transfer(client: Client,  sender: Keypair, transfer_fields: CreateTra
 
     block_hash: BlockHash = None
     if client.clean_response == False:
-        raw_block_hash: RPCResponse[BlockHashType] = client.get_latest_blockhas(
+        raw_block_hash: RPCResponse[BlockHashType] = client.get_latest_blockhash(
             commitment=commitment)
         block_hash: BlockHash = BlockHash(raw_block_hash['result']['value'])
     else:
-        block_hash: BlockHash = client.get_latest_blockhas(
+        block_hash: BlockHash = client.get_latest_blockhash(
             commitment=commitment)
 
     transaction = Transaction(instructions=[instruction], signers=[


### PR DESCRIPTION
Fixed a bug in solana_pay/create_transfer.py where the function was incorrectly calling `client.get_latest_blockhas()` instead of `client.get_latest_blockhash()`. This typo would cause AttributeError exceptions when using the create_transfer function.