### PR TITLE
docs: add instructions for setting additional fees during network congestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,36 @@ balance = client.get_balance(public_key)
 print(balance)
 ```
 
+## ⏱ Handling Congestion with Compute Budget Instructions
+
+On Solana, transaction fees are based on compute units consumed. During high network load, your transaction may fail or be delayed unless additional compute resources are allocated.
+
+You can manually increase the compute unit limit and the price per unit using Solathon's `ComputeBudgetProgram`. This is especially useful when the network is congested.
+
+```python
+from solathon import Client, Transaction, PublicKey, Keypair
+from solathon.core.instructions import transfer
+from solathon.core import ComputeBudgetProgram
+
+client = Client("https://api.devnet.solana.com")
+sender = Keypair()
+receiver = PublicKey("DESTINATION_PUBLIC_KEY")
+
+# Optional: Increase compute resources
+compute_limit_ix = ComputeBudgetProgram.set_compute_unit_limit(1_000_000)
+compute_price_ix = ComputeBudgetProgram.set_compute_unit_price(1)  # micro-lamports per unit
+
+# Transfer instruction
+transfer_ix = transfer(from_public_key=sender.public_key, to_public_key=receiver, lamports=10_000)
+
+# Create and send transaction
+tx = Transaction(
+    instructions=[compute_limit_ix, compute_price_ix, transfer_ix],
+    signers=[sender]
+)
+result = client.send_transaction(tx)
+print("Transaction signature:", result)
+```
+
 # 🗃️ Contribution
 Drop a pull request for anything which seems wrong or can be improved, could be a small typo or an entirely new feature! Checkout [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to proceed.

--- a/solathon/core/__init__.py
+++ b/solathon/core/__init__.py
@@ -1,1 +1,3 @@
 """Solathon core"""
+
+from .compute_budget import ComputeBudgetProgram

--- a/solathon/core/compute_budget.py
+++ b/solathon/core/compute_budget.py
@@ -1,0 +1,24 @@
+from solathon.core.instructions import Instruction
+
+COMPUTE_BUDGET_PROGRAM_ID = "ComputeBudget111111111111111111111111111111"
+
+class ComputeBudgetProgram:
+    @staticmethod
+    def set_compute_unit_limit(units: int) -> Instruction:
+        # 0 = tag for set compute unit limit
+        data = bytes([0]) + units.to_bytes(4, "little")
+        return Instruction(
+            program_id=COMPUTE_BUDGET_PROGRAM_ID,
+            accounts=[],
+            data=data
+        )
+
+    @staticmethod
+    def set_compute_unit_price(micro_lamports: int) -> Instruction:
+        # 3 = tag for set compute unit price
+        data = bytes([3]) + micro_lamports.to_bytes(8, "little")
+        return Instruction(
+            program_id=COMPUTE_BUDGET_PROGRAM_ID,
+            accounts=[],
+            data=data
+        )

--- a/tests/utils/test_compute_budget.py
+++ b/tests/utils/test_compute_budget.py
@@ -1,0 +1,13 @@
+from solathon.core.compute_budget import ComputeBudgetProgram
+
+def test_set_compute_unit_limit():
+    instruction = ComputeBudgetProgram.set_compute_unit_limit(1000)
+    assert instruction.program_id == "ComputeBudget111111111111111111111111111111"
+    assert instruction.data[0] == 0  # Tag for set_compute_unit_limit
+    assert int.from_bytes(instruction.data[1:5], "little") == 1000
+
+def test_set_compute_unit_price():
+    instruction = ComputeBudgetProgram.set_compute_unit_price(10)
+    assert instruction.program_id == "ComputeBudget111111111111111111111111111111"
+    assert instruction.data[0] == 3  # Tag for set_compute_unit_price
+    assert int.from_bytes(instruction.data[1:9], "little") == 10


### PR DESCRIPTION
The ComputeBudgetProgram class is now implemented as requested.  
- Both set_compute_unit_limit and set_compute_unit_price methods have been added.
- Tests for both methods are included in tests/test_compute_budget.py.
- Documentation and usage examples are now accurate and match the implementation.

close:#88

Let me know if you need any further changes!