### PR TITLE
v1.1.0: Full Solana Agave v2.0 RPC update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 
 <p align="center">
   <a href="https://pypi.org/project/solathon/" target="_blank"><img src="https://badge.fury.io/py/solathon.svg" alt="PyPI version"></a>
-  <a href="https://github.com/GitBolt/solathon/blob/master/LICENSE" target="_blank"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License"></a>
+  <a href="https://github.com/SuperteamDAO/solathon/blob/master/LICENSE" target="_blank"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License"></a>
   <br>
 </p>
 
 <h1 align="center">Solathon</h1>
 
-Solathon is a high performance, easy to use and feature-rich Solana SDK for Python. Easy for beginners, powerful for real world applications.
+Solathon is a high performance, easy to use and feature-rich Solana SDK for Python. Easy for beginners, powerful for real world applications. **Fully compatible with Solana Agave v2.0.**
 
 # ✨ Getting started
 ## Installation
@@ -28,11 +28,11 @@ pip install solathon
 ```python
 from solathon import Client
 
+# Works with any RPC endpoint — devnet, mainnet, or custom (Helius, QuickNode, etc.)
 client = Client("https://api.devnet.solana.com")
 ```
 ## Basic usage example
 ```python
-# Basic example of fetching a public key's balance
 from solathon import Client, PublicKey
 
 client = Client("https://api.devnet.solana.com")
@@ -40,6 +40,136 @@ public_key = PublicKey("B3BhJ1nvPvEhx3hq3nfK8hx4WYcKZdbhavSobZEA44ai")
 
 balance = client.get_balance(public_key)
 print(balance)
+```
+
+# 📋 Supported RPC Methods
+
+All methods are available on both `Client` (sync) and `AsyncClient` (async).
+
+### Account
+| Method | Description |
+|--------|-------------|
+| `get_account_info` | Returns all account info for a public key |
+| `get_balance` | Returns lamport balance |
+| `get_multiple_accounts` | Returns account info for multiple keys |
+| `get_program_accounts` | Returns all accounts owned by a program |
+| `get_largest_accounts` | Returns 20 largest accounts by balance |
+| `get_minimum_balance_for_rent_exemption` | Min balance for rent exemption |
+
+### Block
+| Method | Description |
+|--------|-------------|
+| `get_block` | Returns block info for a slot |
+| `get_block_height` | Current block height |
+| `get_block_production` | Block production info |
+| `get_block_commitment` | Commitment for a block |
+| `get_blocks` | List of confirmed blocks in range |
+| `get_blocks_with_limit` | Confirmed blocks from start slot |
+| `get_block_time` | Estimated production time of a block |
+| `get_latest_blockhash` | Latest blockhash |
+| `is_blockhash_valid` | Check if blockhash is still valid |
+
+### Cluster & Node
+| Method | Description |
+|--------|-------------|
+| `get_cluster_nodes` | All nodes in the cluster |
+| `get_epoch_info` | Current epoch info |
+| `get_epoch_schedule` | Epoch schedule |
+| `get_first_available_block` | Lowest confirmed block |
+| `get_genesis_hash` | Genesis hash |
+| `get_health` | Node health status |
+| `get_identity` | Node identity pubkey |
+| `get_version` | Node software version |
+| `get_highest_snapshot_slot` | Highest snapshot slot |
+| `get_leader_schedule` | Leader schedule for epoch |
+| `get_max_retransmit_slot` | Max retransmit slot |
+| `get_max_shred_insert_slot` | Max shred insert slot |
+| `get_slot` | Current slot |
+| `get_slot_leader` | Current slot leader |
+| `get_slot_leaders` | Slot leaders for range |
+| `minimum_ledger_slot` | Min slot in ledger |
+| `get_vote_accounts` | Vote account info |
+| `get_recent_performance_samples` | Recent performance samples |
+
+### Transaction
+| Method | Description |
+|--------|-------------|
+| `get_transaction` | Transaction details by signature |
+| `get_transaction_count` | Total transaction count |
+| `get_signatures_for_address` | Transaction signatures for an address |
+| `get_signature_statuses` | Statuses for transaction signatures |
+| `send_transaction` | Sign and send a transaction |
+| `simulate_transaction` | Simulate without broadcasting |
+| `request_airdrop` | Request SOL airdrop (devnet/testnet) |
+
+### Token (SPL)
+| Method | Description |
+|--------|-------------|
+| `get_token_accounts_by_owner` | SPL token accounts by owner |
+| `get_token_accounts_by_delegate` | SPL token accounts by delegate |
+| `get_token_account_balance` | Token balance of an account |
+| `get_token_supply` | Total supply of an SPL token |
+| `get_token_largest_accounts` | Top 20 holders of an SPL token |
+
+### Fees & Staking
+| Method | Description |
+|--------|-------------|
+| `get_fee_for_message` | Fee for a message |
+| `get_recent_prioritization_fees` | Recent priority fee data |
+| `get_stake_minimum_delegation` | Minimum stake delegation |
+
+### Inflation & Supply
+| Method | Description |
+|--------|-------------|
+| `get_inflation_governor` | Inflation governor |
+| `get_inflation_rate` | Current inflation rate |
+| `get_inflation_reward` | Staking rewards for addresses |
+| `get_supply` | SOL supply info |
+
+# 🔑 Keypair & Transaction
+
+```python
+from solathon import Keypair, Transaction, PublicKey
+from solathon.core.instructions import transfer
+
+# Generate new keypair
+sender = Keypair()
+print(f"Public key: {sender.public_key}")
+
+# Or load from private key
+sender = Keypair.from_private_key("your_base58_private_key")
+
+# Or from Solana CLI JSON file
+sender = Keypair.from_file("~/.config/solana/id.json")
+
+# Build and send a transfer
+receiver = PublicKey("ReceiverPublicKeyHere")
+instruction = transfer(sender.public_key, receiver, lamports=1000000)
+
+transaction = Transaction(instructions=[instruction], signers=[sender])
+client.send_transaction(transaction)
+```
+
+# ⚡ Async Client
+
+```python
+import asyncio
+from solathon import AsyncClient
+
+async def main():
+    client = AsyncClient("https://api.devnet.solana.com")
+    balance = await client.get_balance("B3BhJ1nvPvEhx3hq3nfK8hx4WYcKZdbhavSobZEA44ai")
+    print(balance)
+
+asyncio.run(main())
+```
+
+# 💸 Solana Pay
+
+```python
+from solathon.solana_pay import encode_url
+
+url = encode_url(recipient="ReceiverPubkey", amount=1.5, label="My Store")
 ```
 
 # 🗃️ Contribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "solathon"
-version = "1.0.7"
+version = "1.1.0"
 description = "A high-performance, easy-to-use, and feature-rich Solana SDK for Python."
 license = "MIT"
 authors = ["GitBolt"]

--- a/solathon/__init__.py
+++ b/solathon/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.7"
+__version__ = "1.1.0"
 
 from .client import Client
 from .async_client import AsyncClient

--- a/solathon/async_client.py
+++ b/solathon/async_client.py
@@ -1,531 +1,545 @@
 from __future__ import annotations
 
-from .utils import validate_commitment
-from typing import Any, List, Text, Union, Optional, Dict
+from typing import Any, Dict, List, Literal, Optional, Text, Union
+
+from .utils import RPCRequestError, validate_commitment
 from .publickey import PublicKey
 from .core.http import AsyncHTTPClient
-from .core.types import RPCResponse
-from .transaction import Transaction
-from .utils import validate_commitment
-from .publickey import PublicKey
 from .transaction import Transaction
 from .core.types import (
     Commitment,
     RPCResponse,
-)
-
-ENDPOINTS = (
-    "https://api.mainnet-beta.solana.com",
-    "https://api.devnet.solana.com",
-    "https://api.testnet.solana.com",
+    AccountInfo,
+    Block,
+    BlockProduction,
+    BlockCommitment,
+    BlockHash,
+    ClusterNode,
+    Epoch,
+    EpochSchedule,
+    InflationGovernor,
+    InflationRate,
+    InflationReward,
+    LargestAccounts,
+    ProgramAccount,
+    PubKeyIdentity,
+    RecentPerformanceSamples,
+    SignatureStatus,
+    Supply,
+    TransactionSignature,
+    TransactionElement,
 )
 
 
 class AsyncClient:
-    def __init__(self, endpoint: Text, local: bool = False):
+    def __init__(
+        self, endpoint: Text, local: bool = False, clean_response: bool = True
+    ):
         """
-        Initializes an AsyncClient object.
+        Async Solana RPC client.
 
         Args:
-        - endpoint (str): The endpoint URL for the Solana RPC server.
-        - local (bool): Whether to use a local development endpoint or not. Defaults to False.
-
-        Raises:
-        - ValueError: If the endpoint is not valid and not a local development endpoint.
+            endpoint (str): The RPC endpoint URL.
+            local (bool): Skip endpoint validation. Defaults to False.
+            clean_response (bool): Whether to unwrap RPC responses. Defaults to True.
         """
-        if not local and endpoint not in ENDPOINTS:
-            raise ValueError(
-                "Invalid cluster RPC endpoint provided"
-                " (Refer to https://docs.solana.com/cluster/rpc-endpoints)."
-                " Use the argument local to use a local development endpoint."
-            )
+        if not local and not endpoint.startswith(("http://", "https://")):
+            raise ValueError("Invalid RPC endpoint. Must be a valid HTTP/HTTPS URL.")
         self.http = AsyncHTTPClient(endpoint)
         self.endpoint = endpoint
+        self.clean_response = clean_response
 
     async def refresh_http(self) -> None:
-        """
-        Refreshes the HTTP client.
-        """
         await self.http.refresh()
 
-    async def get_account_info(self, public_key: PublicKey | Text) -> RPCResponse:
-        """
-        Returns the account information for a given public key.
-
-        Args:
-        - public_key (PublicKey | str): The public key of the account.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getAccountInfo", [public_key])
-
-    async def get_balance(self, public_key: PublicKey | Text) -> RPCResponse:
-        """
-        Returns the balance of a given account.
-
-        Args:
-        - public_key (PublicKey | str): The public key of the account.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getBalance", [public_key])
-
-    async def get_block(self, slot: int) -> RPCResponse:
-        """
-        Returns the block information for a given slot.
-
-        Args:
-        - slot (int): The slot of the block.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getBlock", [slot])
-
-    async def get_block_height(self) -> RPCResponse:
-        """
-        Returns the current block height.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getBlockHeight", [None])
-
-    async def get_block_production(self) -> RPCResponse:
-        """
-        Returns the block production information.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getBlockProduction", [None])
-
-    async def get_block_commitment(self, block: int) -> RPCResponse:
-        """
-        Returns the block commitment information for a given block.
-
-        Args:
-        - block (int): The block number.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getBlockCommitment", [block])
-
-    async def get_blocks(
-        self, start_slot: int, end_slot: int | None = None
-    ) -> RPCResponse:
-        """
-        Returns the block information for a range of slots.
-
-        Args:
-        - start_slot (int): The starting slot.
-        - end_slot (int | None): The ending slot. Defaults to None.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        params = [start_slot]
-        if end_slot:
-            params.append(end_slot)
-
-        return await self.build_and_send_request_async("getBlocks", params)
-
-    async def get_blocks_with_limit(self, start_slot: int, limit: int) -> RPCResponse:
-        """
-        Returns the block information for a range of slots with a limit.
-
-        Args:
-        - start_slot (int): The starting slot.
-        - limit (int): The maximum number of blocks to return.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async(
-            "getBlocksWithLimit", [start_slot, limit]
-        )
-
-    async def get_block_time(self, block: int) -> RPCResponse:
-        """
-        Returns the block time for a given block.
-
-        Args:
-        - block (int): The block number.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getBlockTime", [block])
-
-    async def get_cluster_nodes(self) -> RPCResponse:
-        """
-        Returns the cluster nodes information.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getClusterNodes", [None])
-
-    async def get_epoch_info(self) -> RPCResponse:
-        """
-        Returns the epoch information.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getEpochInfo", [None])
-
-    async def get_epoch_schedule(self) -> RPCResponse:
-        """
-        Returns the epoch schedule information.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getEpochSchedule", [None])
-
-    async def get_fee_for_message(self, message: Text) -> RPCResponse:
-        """
-        Returns the fee for a given message.
-
-        Args:
-        - message (str): The message.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getFeeForMessage", [message])
-
-    async def get_first_available_block(self) -> RPCResponse:
-        """
-        Returns the first available block.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getFirstAvailableBlock", [None])
-
-    async def get_genesis_hash(self) -> RPCResponse:
-        """
-        Returns the genesis hash.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getGenesisHash", [None])
-
-    async def get_health(self) -> RPCResponse:
-        """
-        Returns the health information.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getHealth", [None])
-
-    async def get_identity(self) -> RPCResponse:
-        """
-        Returns the identity information.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getIdentity", [None])
-
-    async def get_inflation_governor(self) -> RPCResponse:
-        """
-        Returns the inflation governor information.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getInflationGovernor", [None])
-
-    async def get_inflation_rate(self) -> RPCResponse:
-        """
-        Returns the inflation rate.
-
-        Returns:
-        - RPCResponse: The response from the Solana RPC server.
-        """
-        return await self.build_and_send_request_async("getInflationRate", [None])
-
-    async def get_inflation_reward(self, addresses: List[Text]) -> RPCResponse:
-        """
-        Get the inflation reward for a list of addresses.
-
-        Args:
-            addresses (List[Text]): A list of addresses to get the inflation reward for.
-
-        Returns:
-            RPCResponse: The response from the RPC server.
-        """
-        return await self.build_and_send_request_async("getInflationReward", [addresses])
-
-    async def get_largest_accounts(self) -> RPCResponse:
-        """
-        Returns the largest accounts on the Solana blockchain.
-
-        :return: An RPCResponse object containing the response from the Solana node.
-        """
-        return await self.build_and_send_request_async("getLargestAccounts", [None])
-
-    async def get_leader_schedule(self) -> RPCResponse:
-        """
-        Sends a request to the Solana RPC endpoint to retrieve the leader schedule.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        return await self.build_and_send_request_async("getLeaderSchedule", [None])
-
-    async def get_max_retransmit_slot(self) -> RPCResponse:
-        """
-        Sends a request to get the maximum retransmit slot from the server.
-
-        Returns:
-            An RPCResponse object containing the server's response.
-        """
-        return await self.build_and_send_request_async("getMaxRetransmitSlot", [None])
-
-    async def get_max_shred_insert_slot(self) -> RPCResponse:
-        """
-        Sends a request to get the maximum shred insert slot from the Solana RPC endpoint.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        return await self.build_and_send_request_async("getMaxShredInsertSlot", [None])
-
-    async def get_minimum_balance_for_rent_exemption(
-        self, acct_length: int
-    ) -> RPCResponse:
-        """
-        Returns the minimum balance needed to create an account with the given data size.
-
-        :param acct_length: The length of the account data.
-        :type acct_length: int
-        :return: The minimum balance needed to create an account with the given data size.
-        :rtype: RPCResponse
-        """
-        return await self.build_and_send_request_async(
-            "getMinimumBalanceForRentExemption", [acct_length]
-        )
-
-    async def get_multiple_accounts(self, pubkeys: List) -> RPCResponse:
-        """
-        Sends a request to the Solana RPC endpoint to retrieve multiple accounts
-        associated with the given public keys.
-
-        Args:
-            pubkeys (list): A list of public keys associated with the accounts to retrieve.
-
-        Returns:
-            RPCResponse: The response from the Solana RPC endpoint.
-        """
-        return await self.build_and_send_request_async("getMultipleAccounts", [pubkeys])
-
-    async def get_program_accounts(self, public_key: PublicKey) -> RPCResponse:
-        """
-        Returns accounts associated with a given program.
-
-        Args:
-            public_key (PublicKey): The public key of the program.
-
-        Returns:
-            RPCResponse: The response from the RPC server.
-        """
-        return await self.build_and_send_request_async("getProgramAccounts", [public_key])
-
-    async def get_latest_blockhash(self) -> RPCResponse:
-        """
-        Returns a recent blockhash from the ledger.
-
-        :return: RPCResponse object containing the recent blockhash.
-        """
-        return await self.build_and_send_request_async("getLatestBlockhash", [None])
-
-    async def get_recent_performance_samples(self) -> RPCResponse:
-        """
-        Sends a request to the server to get recent performance samples.
-
-        Returns:
-            RPCResponse: The response from the server.
-        """
-        return await self.build_and_send_request_async("getRecentPerformanceSamples", [None])
-
-    async def get_signatures_for_address(self, acct_address: Text) -> RPCResponse:
-        """
-        Returns signatures for a given account address.
-
-        :param acct_address: The account address to get signatures for.
-        :type acct_address: str
-        :return: The RPC response containing the signatures for the account address.
-        :rtype: RPCResponse
-        """
-        return await self.build_and_send_request_async(
-            "getSignaturesForAddress", [acct_address]
-        )
-
-    async def get_signature_statuses(self, transaction_sigs: List[Text]) -> RPCResponse:
-        """
-        Returns the current status of a list of signatures.
-
-        Args:
-            transaction_sigs (List[str]): List of transaction signatures to check status for.
-
-        Returns:
-            RPCResponse: Response object containing the status of the signatures.
-        """
-        return await self.build_and_send_request_async(
-            "getSignatureStatuses", [transaction_sigs]
-        )
-
-    async def get_slot(self) -> RPCResponse:
-        """
-        Sends a request to the Solana RPC endpoint to retrieve the current slot.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        return await self.build_and_send_request_async("getSlot", [None])
-
-    async def get_supply(self) -> RPCResponse:
-        """
-        Sends a request to the Solana blockchain to retrieve the current supply.
-
-        Returns:
-            RPCResponse: The response from the Solana blockchain.
-        """
-        return await self.build_and_send_request_async("getSupply", [None])
-
-    async def get_token_accounts_by_owner(
-        self, public_key: Union[Text, PublicKey], **kwargs
-    ) -> RPCResponse:
-        """
-        Returns token accounts owned by a particular address.
-
-        Args:
-            public_key (Union[Text, PublicKey]): The public key of the address to query.
-            **kwargs: Additional keyword arguments.
-                mint_id (Optional[Text]): The mint ID of the token to query.
-                program_id (Optional[Text]): The program ID of the token to query.
-                encoding (Optional[Text]): The encoding format of the response. Defaults to "jsonParsed".
-
-        Returns:
-            RPCResponse: The response from the RPC server.
-        """
-        if "mint_id" not in kwargs and "program_id" not in kwargs:
-            raise ValueError(
-                "You must pass either mint_id or program_id keyword argument"
-            )
-
-        mint_id = kwargs.get("mint_id")
-        program_id = kwargs.get("program_id")
-        # Who doesn't like JSON?
-        encoding = kwargs.get("encoding", "jsonParsed")
-        return await self.build_and_send_request_async(
-            "getTokenAccountsByOwner",
-            [
-                str(public_key),
-                {"mint": mint_id} if mint_id else {"programId": program_id},
-                {"encoding": encoding},
-            ],
-        )
-
-    async def get_token_account_balance(
-        self, token_account: Text | PublicKey, commitment: Optional[Commitment]=None,
-    ) -> RPCResponse:
-        """
-        Returns the token account balance for the specified owner.
-
-        Args:
-            token_account (str | PublicKey): The token account pubkey.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request_async(
-            "getTokenAccountBalance",
-            [
-                str(token_account),
-            ],
-        )
+    # ========================================================================
+    # Account Methods
+    # ========================================================================
+
+    async def get_account_info(
+        self, public_key: PublicKey | Text, commitment: Optional[Commitment] = None
+    ):
+        config: Dict[str, Any] = {"encoding": "base64"}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = await self.build_and_send_request("getAccountInfo", [str(public_key), config])
         if self.clean_response:
-            return response['value']
+            if response["value"] is None:
+                raise RPCRequestError(f"Account details not found: {public_key}")
+            return AccountInfo(response["value"])
         return response
 
+    async def get_balance(
+        self, public_key: PublicKey | Text, commitment: Optional[Commitment] = None
+    ):
+        params: list = [str(public_key)]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getBalance", params)
+        if self.clean_response:
+            return response["value"]
+        return response
 
-    async def get_transaction(self, signature: Text) -> RPCResponse:
-        """
-        Sends a request to the Solana RPC endpoint to retrieve a transaction by its signature.
+    async def get_multiple_accounts(
+        self, pubkeys: List[str], commitment: Optional[Commitment] = None
+    ):
+        config: Dict[str, Any] = {"encoding": "base64"}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = await self.build_and_send_request("getMultipleAccounts", [pubkeys, config])
+        if self.clean_response:
+            return [AccountInfo(a) for a in response["value"] if a]
+        return response
 
-        Args:
-            signature (Text): The signature of the transaction to retrieve.
+    async def get_program_accounts(
+        self, public_key: PublicKey | Text, commitment: Optional[Commitment] = None,
+        filters: Optional[List[Dict]] = None
+    ):
+        config: Dict[str, Any] = {"encoding": "base64"}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        if filters:
+            config["filters"] = filters
+        response = await self.build_and_send_request("getProgramAccounts", [str(public_key), config])
+        if self.clean_response:
+            return [ProgramAccount(a) for a in response]
+        return response
 
-        Returns:
-            RPCResponse: The response from the Solana RPC endpoint.
-        """
-        return await self.build_and_send_request_async("getTransaction", [signature])
+    async def get_largest_accounts(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getLargestAccounts", params if params else [None])
+        if self.clean_response:
+            return [LargestAccounts(a) for a in response["value"]]
+        return response
 
-    # Non "get" methods
-    async def request_airdrop(
-        self, public_key: Union[PublicKey, Text], lamports: int
-    ) -> RPCResponse:
-        """
-        Requests an airdrop of the specified number of lamports to the specified public key.
+    async def get_minimum_balance_for_rent_exemption(
+        self, data_length: int, commitment: Optional[Commitment] = None
+    ):
+        params: list = [data_length]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return await self.build_and_send_request("getMinimumBalanceForRentExemption", params)
 
-        Args:
-            public_key (PublicKey | Text): The public key to receive the airdrop.
-            lamports (int): The number of lamports to request in the airdrop.
+    # ========================================================================
+    # Block Methods
+    # ========================================================================
 
-        Returns:
-            RPCResponse: The response from the Solana JSON RPC API.
-        """
-        return await self.build_and_send_request_async(
-            "requestAirdrop", [public_key, lamports]
+    async def get_block(self, slot: int, max_supported_transaction_version: int = 0):
+        config = {"maxSupportedTransactionVersion": max_supported_transaction_version}
+        response = await self.build_and_send_request("getBlock", [slot, config])
+        if self.clean_response:
+            return Block(response)
+        return response
+
+    async def get_block_height(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return await self.build_and_send_request("getBlockHeight", params if params else [None])
+
+    async def get_block_production(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getBlockProduction", params if params else [None])
+        if self.clean_response:
+            return BlockProduction(response["value"])
+        return response
+
+    async def get_block_commitment(self, block: int):
+        response = await self.build_and_send_request("getBlockCommitment", [block])
+        if self.clean_response:
+            return BlockCommitment(response)
+        return response
+
+    async def get_blocks(self, start_slot: int, end_slot: int | None = None):
+        params: list = [start_slot]
+        if end_slot:
+            params.append(end_slot)
+        return await self.build_and_send_request("getBlocks", params)
+
+    async def get_blocks_with_limit(self, start_slot: int, limit: int):
+        return await self.build_and_send_request("getBlocksWithLimit", [start_slot, limit])
+
+    async def get_block_time(self, block: int):
+        return await self.build_and_send_request("getBlockTime", [block])
+
+    async def get_latest_blockhash(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getLatestBlockhash", params if params else [None])
+        if self.clean_response:
+            return BlockHash(response["value"])
+        return response
+
+    async def is_blockhash_valid(self, blockhash: Text, commitment: Optional[Commitment] = None):
+        params: list = [blockhash]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("isBlockhashValid", params)
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    # ========================================================================
+    # Cluster Methods
+    # ========================================================================
+
+    async def get_cluster_nodes(self):
+        response = await self.build_and_send_request("getClusterNodes", [None])
+        if self.clean_response:
+            return [ClusterNode(n) for n in response]
+        return response
+
+    async def get_epoch_info(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getEpochInfo", params if params else [None])
+        if self.clean_response:
+            return Epoch(response)
+        return response
+
+    async def get_epoch_schedule(self):
+        response = await self.build_and_send_request("getEpochSchedule", [None])
+        if self.clean_response:
+            return EpochSchedule(response)
+        return response
+
+    async def get_first_available_block(self):
+        return await self.build_and_send_request("getFirstAvailableBlock", [None])
+
+    async def get_genesis_hash(self):
+        return await self.build_and_send_request("getGenesisHash", [None])
+
+    async def get_health(self):
+        return await self.build_and_send_request("getHealth", [None])
+
+    async def get_identity(self):
+        response = await self.build_and_send_request("getIdentity", [None])
+        if self.clean_response:
+            return PubKeyIdentity(response)
+        return response
+
+    async def get_version(self):
+        return await self.build_and_send_request("getVersion", [None])
+
+    async def get_highest_snapshot_slot(self):
+        return await self.build_and_send_request("getHighestSnapshotSlot", [None])
+
+    async def get_leader_schedule(self, slot: Optional[int] = None):
+        return await self.build_and_send_request("getLeaderSchedule", [slot])
+
+    async def get_max_retransmit_slot(self):
+        return await self.build_and_send_request("getMaxRetransmitSlot", [None])
+
+    async def get_max_shred_insert_slot(self):
+        return await self.build_and_send_request("getMaxShredInsertSlot", [None])
+
+    async def get_slot(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return await self.build_and_send_request("getSlot", params if params else [None])
+
+    async def get_slot_leader(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return await self.build_and_send_request("getSlotLeader", params if params else [None])
+
+    async def get_slot_leaders(self, start_slot: int, limit: int):
+        return await self.build_and_send_request("getSlotLeaders", [start_slot, limit])
+
+    async def minimum_ledger_slot(self):
+        return await self.build_and_send_request("minimumLedgerSlot", [None])
+
+    async def get_vote_accounts(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return await self.build_and_send_request("getVoteAccounts", params if params else [None])
+
+    # ========================================================================
+    # Fee Methods
+    # ========================================================================
+
+    async def get_fee_for_message(self, message: Text, commitment: Optional[Commitment] = None):
+        params: list = [message]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getFeeForMessage", params)
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    async def get_recent_prioritization_fees(self, addresses: Optional[List[Text]] = None):
+        params: list = []
+        if addresses:
+            params.append(addresses)
+        return await self.build_and_send_request("getRecentPrioritizationFees", params if params else [None])
+
+    # ========================================================================
+    # Inflation Methods
+    # ========================================================================
+
+    async def get_inflation_governor(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getInflationGovernor", params if params else [None])
+        if self.clean_response:
+            return InflationGovernor(response)
+        return response
+
+    async def get_inflation_rate(self):
+        response = await self.build_and_send_request("getInflationRate", [None])
+        if self.clean_response:
+            return InflationRate(response)
+        return response
+
+    async def get_inflation_reward(
+        self, addresses: List[Text], commitment: Optional[Commitment] = None,
+        epoch: Optional[int] = None
+    ):
+        params: list = [addresses]
+        config: Dict[str, Any] = {}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        if epoch is not None:
+            config["epoch"] = epoch
+        if config:
+            params.append(config)
+        response = await self.build_and_send_request("getInflationReward", params)
+        if self.clean_response:
+            return [InflationReward(r) for r in response if r]
+        return response
+
+    # ========================================================================
+    # Supply / Stake
+    # ========================================================================
+
+    async def get_supply(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getSupply", params if params else [None])
+        if self.clean_response:
+            return Supply(response["value"])
+        return response
+
+    async def get_stake_minimum_delegation(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getStakeMinimumDelegation", params if params else [None])
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    # ========================================================================
+    # Token Methods
+    # ========================================================================
+
+    async def get_token_accounts_by_owner(
+        self, public_key: Text | PublicKey, commitment: Optional[Commitment] = None, **kwargs
+    ):
+        if "mint_id" not in kwargs and "program_id" not in kwargs:
+            raise ValueError("You must pass either mint_id or program_id keyword argument")
+        mint_id = kwargs.get("mint_id")
+        program_id = kwargs.get("program_id")
+        encoding = kwargs.get("encoding", "jsonParsed")
+        config: Dict[str, Any] = {"encoding": encoding}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = await self.build_and_send_request(
+            "getTokenAccountsByOwner",
+            [str(public_key), {"mint": mint_id} if mint_id else {"programId": program_id}, config],
         )
+        if self.clean_response:
+            return [ProgramAccount(a) for a in response["value"]]
+        return response
 
-    async def send_transaction(self, transaction: Transaction) -> RPCResponse:
-        """
-        Sends a transaction to the Solana network.
+    async def get_token_accounts_by_delegate(
+        self, delegate: Text | PublicKey, commitment: Optional[Commitment] = None, **kwargs
+    ):
+        if "mint_id" not in kwargs and "program_id" not in kwargs:
+            raise ValueError("You must pass either mint_id or program_id keyword argument")
+        mint_id = kwargs.get("mint_id")
+        program_id = kwargs.get("program_id")
+        encoding = kwargs.get("encoding", "jsonParsed")
+        config: Dict[str, Any] = {"encoding": encoding}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = await self.build_and_send_request(
+            "getTokenAccountsByDelegate",
+            [str(delegate), {"mint": mint_id} if mint_id else {"programId": program_id}, config],
+        )
+        if self.clean_response:
+            return [ProgramAccount(a) for a in response["value"]]
+        return response
 
-        Args:
-            transaction (Transaction): The transaction to send.
+    async def get_token_account_balance(
+        self, token_account: Text | PublicKey, commitment: Optional[Commitment] = None
+    ):
+        params: list = [str(token_account)]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getTokenAccountBalance", params)
+        if self.clean_response:
+            return response["value"]
+        return response
 
-        Returns:
-            RPCResponse: The response from the Solana network.
-        """
-        if not transaction.recent_blockhash:
-            transaction.recent_blockhash = (await self.get_latest_blockhas())[
-                "result"
-            ].blockhash
+    async def get_token_supply(self, mint: Text | PublicKey, commitment: Optional[Commitment] = None):
+        params: list = [str(mint)]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getTokenSupply", params)
+        if self.clean_response:
+            return response["value"]
+        return response
 
+    async def get_token_largest_accounts(self, mint: Text | PublicKey, commitment: Optional[Commitment] = None):
+        params: list = [str(mint)]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = await self.build_and_send_request("getTokenLargestAccounts", params)
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    # ========================================================================
+    # Transaction Methods
+    # ========================================================================
+
+    async def get_transaction(
+        self, signature: Text, max_supported_transaction_version: int = 0,
+        commitment: Optional[Commitment] = None
+    ):
+        config: Dict[str, Any] = {"maxSupportedTransactionVersion": max_supported_transaction_version}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = await self.build_and_send_request("getTransaction", [signature, config])
+        if self.clean_response:
+            if response is None:
+                raise ValueError("Transaction not found")
+            return TransactionElement(response)
+        return response
+
+    async def get_transaction_count(self, commitment: Optional[Commitment] = None):
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return await self.build_and_send_request("getTransactionCount", params if params else [None])
+
+    async def get_signatures_for_address(
+        self, acct_address: Text, limit: Optional[int] = None,
+        before: Optional[Text] = None, until: Optional[Text] = None,
+        commitment: Optional[Commitment] = None,
+    ):
+        params: list = [acct_address]
+        options: Dict[str, Any] = {}
+        if limit is not None:
+            options["limit"] = limit
+        if before is not None:
+            options["before"] = before
+        if until is not None:
+            options["until"] = until
+        if commitment:
+            options.update(validate_commitment(commitment))
+        if options:
+            params.append(options)
+        response = await self.build_and_send_request("getSignaturesForAddress", params)
+        if self.clean_response:
+            return [TransactionSignature(s) for s in response]
+        return response
+
+    async def get_signature_statuses(
+        self, transaction_sigs: List[Text], search_transaction_history: bool = False
+    ):
+        params: list = [transaction_sigs]
+        if search_transaction_history:
+            params.append({"searchTransactionHistory": True})
+        response = await self.build_and_send_request("getSignatureStatuses", params)
+        if self.clean_response:
+            return [SignatureStatus(s) for s in response["value"] if s]
+        return response
+
+    async def get_recent_performance_samples(self, limit: Optional[int] = None):
+        params: list = [limit] if limit else [None]
+        response = await self.build_and_send_request("getRecentPerformanceSamples", params)
+        if self.clean_response:
+            return [RecentPerformanceSamples(s) for s in response]
+        return response
+
+    async def simulate_transaction(
+        self, transaction: Text, sig_verify: bool = False,
+        commitment: Optional[Commitment] = None,
+        replace_recent_blockhash: bool = False,
+    ):
+        config: Dict[str, Any] = {
+            "encoding": "base64",
+            "sigVerify": sig_verify,
+            "replaceRecentBlockhash": replace_recent_blockhash,
+        }
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = await self.build_and_send_request("simulateTransaction", [transaction, config])
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    # ========================================================================
+    # Action Methods
+    # ========================================================================
+
+    async def request_airdrop(
+        self, public_key: PublicKey | Text, lamports: int,
+        commitment: Optional[Commitment] = None
+    ):
+        params: list = [str(public_key), lamports]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return await self.build_and_send_request("requestAirdrop", params)
+
+    async def send_transaction(
+        self, transaction: Transaction, options: Optional[Dict] = None
+    ):
+        recent_blockhash = transaction.recent_blockhash
+        if recent_blockhash is None:
+            blockhash_resp = await self.get_latest_blockhash()
+            recent_blockhash = blockhash_resp.blockhash
+
+        if options is None:
+            options = {"encoding": "base64"}
+
+        transaction.recent_blockhash = recent_blockhash
         transaction.sign()
 
-        return await self.build_and_send_request_async(
-            "sendTransaction", [transaction.serialize(), {"encoding": "base64"}]
+        return await self.build_and_send_request(
+            "sendTransaction", [transaction.serialize(), options]
         )
 
-    async def build_and_send_request_async(
-        self, method: Text, params: List[Any]
-    ) -> RPCResponse:
-        """
-        Builds and sends an RPC request to the server.
+    # ========================================================================
+    # Internal
+    # ========================================================================
 
-        Args:
-            method (Text): The RPC method to call.
-            params (List[Any]): The parameters to pass to the RPC method.
-
-        Returns:
-            RPCResponse: The response from the server.
-        """
-        data: Dict[Text, Any] = self.http.build_data(method=method, params=params)
-        res: RPCResponse = await self.http.send(data)
+    async def build_and_send_request(
+        self, method: str, params: List[Any]
+    ):
+        data: Dict[str, Any] = self.http.build_data(method=method, params=params)
+        res = await self.http.send(data)
+        if self.clean_response:
+            if "error" in res:
+                raise RPCRequestError(
+                    f"RPC Error {res['error']['code']}: {res['error']['message']}"
+                )
+            result = res.get("result")
+            if result is None or isinstance(result, (dict, list, str, int, float, bool)):
+                return result
+            else:
+                raise RPCRequestError(f"Unexpected response type: {type(result).__name__}")
         return res

--- a/solathon/client.py
+++ b/solathon/client.py
@@ -49,63 +49,44 @@ from .core.types import (
     TransactionElementType,
 )
 
-ENDPOINTS = (
-    "https://api.mainnet-beta.solana.com",
-    "https://api.devnet.solana.com",
-    "https://api.testnet.solana.com",
-)
-
 
 class Client:
     def __init__(
         self, endpoint: Text, local: bool = False, clean_response: bool = True
     ):
         """
-        Initializes a new instance of the Client class.
+        Initializes the Solana RPC client.
 
         Args:
-            endpoint (str): The endpoint to connect to.
-            local (bool, optional): Whether to use a local development endpoint. Defaults to False.
-            clean_response (bool, optional): Whether to clean the response from the RPC endpoint. Defaults to True.
-
-        Raises:
-            ValueError: If the endpoint is not valid and local is False.
+            endpoint (str): The RPC endpoint URL (any valid HTTP/HTTPS URL).
+            local (bool, optional): Whether to skip endpoint validation. Defaults to False.
+            clean_response (bool, optional): Whether to unwrap RPC responses. Defaults to True.
         """
-        if not local and endpoint not in ENDPOINTS:
+        if not local and not endpoint.startswith(("http://", "https://")):
             raise ValueError(
-                "Invalid cluster RPC endpoint provided"
-                " (Refer to https://docs.solana.com/cluster/rpc-endpoints)."
-                " Use the argument local to use a local development endpoint."
+                "Invalid RPC endpoint. Must be a valid HTTP/HTTPS URL."
             )
         self.http = HTTPClient(endpoint)
         self.endpoint = endpoint
         self.clean_response = clean_response
 
     def refresh_http(self) -> None:
-        """
-        Refreshes the HTTP client.
-        """
         self.http.refresh()
+
+    # ========================================================================
+    # Account Methods
+    # ========================================================================
 
     def get_account_info(
         self, public_key: PublicKey | Text, commitment: Optional[Commitment] = None
     ) -> RPCResponse[AccountInfoType] | AccountInfo:
-        """
-        Returns all the account info for the specified public key.
-
-        Args:
-            public_key (PublicKey | str): The public key of the account.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request("getAccountInfo", [public_key, {
-            "encoding": "base64"
-        }])
+        """Returns all account info for the specified public key."""
+        config: Dict[str, Any] = {"encoding": "base64"}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = self.build_and_send_request("getAccountInfo", [str(public_key), config])
         if self.clean_response:
-            if response["value"] == None:
+            if response["value"] is None:
                 raise RPCRequestError(f"Account details not found: {public_key}")
             return AccountInfo(response["value"])
         return response
@@ -113,34 +94,78 @@ class Client:
     def get_balance(
         self, public_key: PublicKey | Text, commitment: Optional[Commitment] = None
     ) -> RPCResponse[int] | int:
-        """
-        Returns the balance of the specified public key.
-
-        Args:
-            public_key (PublicKey | Text): The public key of the account.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request("getBalance", [public_key, commitment])
+        """Returns the lamport balance of the account."""
+        params: list = [str(public_key)]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getBalance", params)
         if self.clean_response:
             return response["value"]
-
         return response
 
-    def get_block(self, slot: int) -> RPCResponse[BlockType] | Block:
-        """
-        Returns the block at the specified slot.
+    def get_multiple_accounts(
+        self, pubkeys: List[str], commitment: Optional[Commitment] = None
+    ) -> RPCResponse[List[AccountInfoType]] | List[AccountInfo]:
+        """Returns account info for a list of public keys."""
+        config: Dict[str, Any] = {"encoding": "base64"}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = self.build_and_send_request("getMultipleAccounts", [pubkeys, config])
+        if self.clean_response:
+            return [AccountInfo(account) for account in response["value"] if account]
+        return response
 
-        Args:
-            slot (int): The slot of the block.
+    def get_program_accounts(
+        self, public_key: PublicKey | Text, commitment: Optional[Commitment] = None,
+        filters: Optional[List[Dict]] = None
+    ) -> RPCResponse[List[ProgramAccountType]] | List[ProgramAccount]:
+        """Returns all accounts owned by the specified program."""
+        config: Dict[str, Any] = {"encoding": "base64"}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        if filters:
+            config["filters"] = filters
+        response = self.build_and_send_request("getProgramAccounts", [str(public_key), config])
+        if self.clean_response:
+            return [ProgramAccount(account) for account in response]
+        return response
 
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        response = self.build_and_send_request("getBlock", [slot])
+    def get_largest_accounts(
+        self, commitment: Optional[Commitment] = None, filter: Optional[Literal["circulating", "nonCirculating"]] = None
+    ) -> RPCResponse[List[LargestAccountsType]] | List[LargestAccounts]:
+        """Returns the 20 largest accounts by lamport balance."""
+        config: Dict[str, Any] = {}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        if filter:
+            config["filter"] = filter
+        response = self.build_and_send_request("getLargestAccounts", [config] if config else [None])
+        if self.clean_response:
+            return [LargestAccounts(account) for account in response["value"]]
+        return response
+
+    def get_minimum_balance_for_rent_exemption(
+        self, data_length: int, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[int] | int:
+        """Returns minimum balance required to make account rent-exempt."""
+        params: list = [data_length]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return self.build_and_send_request("getMinimumBalanceForRentExemption", params)
+
+    # ========================================================================
+    # Block Methods
+    # ========================================================================
+
+    def get_block(
+        self, slot: int, commitment: Optional[Commitment] = None,
+        max_supported_transaction_version: Optional[int] = 0
+    ) -> RPCResponse[BlockType] | Block:
+        """Returns identity and transaction info about a confirmed block."""
+        config: Dict[str, Any] = {"maxSupportedTransactionVersion": max_supported_transaction_version}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = self.build_and_send_request("getBlock", [slot, config])
         if self.clean_response:
             return Block(response)
         return response
@@ -148,32 +173,20 @@ class Client:
     def get_block_height(
         self, commitment: Optional[Commitment] = None
     ) -> RPCResponse[int] | int:
-        """
-        Returns the current block height.
-
-        Args:
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        return self.build_and_send_request("getBlockHeight", [commitment])
+        """Returns the current block height."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return self.build_and_send_request("getBlockHeight", params if params else [None])
 
     def get_block_production(
         self, commitment: Optional[Commitment] = None
     ) -> RPCResponse[BlockProductionType] | BlockProduction:
-        """
-        Returns the block production information.
-
-        Args:
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request("getBlockProduction", [commitment])
+        """Returns recent block production information."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getBlockProduction", params if params else [None])
         if self.clean_response:
             return BlockProduction(response["value"])
         return response
@@ -181,81 +194,64 @@ class Client:
     def get_block_commitment(
         self, block: int
     ) -> RPCResponse[BlockCommitmentType] | BlockCommitment:
-        """
-        Returns the block commitment information for the specified block.
-
-        Args:
-            block (int): The block number.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns commitment for a particular block."""
         response = self.build_and_send_request("getBlockCommitment", [block])
         if self.clean_response:
             return BlockCommitment(response)
         return response
 
     def get_blocks(
-        self,
-        start_slot: int,
-        end_slot: int | None = None,
+        self, start_slot: int, end_slot: int | None = None,
         commitment: Optional[Commitment] = None,
     ) -> RPCResponse[List[int]] | List[int]:
-        """
-        Returns the blocks in the specified range.
-
-        Args:
-            start_slot (int): The start slot.
-            end_slot (int | None, optional): The end slot. Defaults to None.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        params = [start_slot]
+        """Returns a list of confirmed blocks between two slots."""
+        params: list = [start_slot]
         if end_slot:
             params.append(end_slot)
-        params.append(commitment)
-
+        if commitment:
+            params.append(validate_commitment(commitment))
         return self.build_and_send_request("getBlocks", params)
 
     def get_blocks_with_limit(
         self, start_slot: int, limit: int
     ) -> RPCResponse[List[int]] | List[int]:
-        """
-        Returns the blocks in the specified range with a limit.
-
-        Args:
-            start_slot (int): The start slot.
-            limit (int): The limit.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns a list of confirmed blocks starting at the given slot."""
         return self.build_and_send_request("getBlocksWithLimit", [start_slot, limit])
 
     def get_block_time(self, block: int) -> RPCResponse[int] | int:
-        """
-        Returns the block time for the specified block.
-
-        Args:
-            block (int): The block number.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns the estimated production time of a block."""
         return self.build_and_send_request("getBlockTime", [block])
 
-    def get_cluster_nodes(
-        self,
-    ) -> RPCResponse[List[ClusterNodeType]] | List[ClusterNode]:
-        """
-        Returns the cluster nodes.
+    def get_latest_blockhash(
+        self, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[BlockHashType] | BlockHash:
+        """Returns the latest blockhash."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getLatestBlockhash", params if params else [None])
+        if self.clean_response:
+            return BlockHash(response["value"])
+        return response
 
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+    def is_blockhash_valid(
+        self, blockhash: Text, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[bool] | bool:
+        """Returns whether a blockhash is still valid."""
+        params: list = [blockhash]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("isBlockhashValid", params)
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    # ========================================================================
+    # Cluster Methods
+    # ========================================================================
+
+    def get_cluster_nodes(self) -> RPCResponse[List[ClusterNodeType]] | List[ClusterNode]:
+        """Returns information about all nodes participating in the cluster."""
         response = self.build_and_send_request("getClusterNodes", [None])
         if self.clean_response:
             return [ClusterNode(node) for node in response]
@@ -264,527 +260,404 @@ class Client:
     def get_epoch_info(
         self, commitment: Optional[Commitment] = None
     ) -> RPCResponse[EpochType] | Epoch:
-        """
-        Returns the epoch information.
-
-        Args:
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request("getEpochInfo", [commitment])
+        """Returns information about the current epoch."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getEpochInfo", params if params else [None])
         if self.clean_response:
             return Epoch(response)
         return response
 
     def get_epoch_schedule(self) -> RPCResponse[EpochScheduleType] | EpochSchedule:
-        """
-        Returns the epoch schedule.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns the epoch schedule."""
         response = self.build_and_send_request("getEpochSchedule", [None])
         if self.clean_response:
             return EpochSchedule(response)
         return response
 
-    def get_fee_for_message(
-        self, message: Text, commitment: Optional[Commitment] = None
-    ) -> RPCResponse[int] | int:
-        """
-        Returns the fee for the specified message.
-
-        Args:
-            message (str): The message.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request(
-            "getFeeForMessage", [message, commitment]
-        )
-        if self.clean_response:
-            return response["value"]
-        return response
-
-
     def get_first_available_block(self) -> RPCResponse[int] | int:
-        """
-        Returns the first available block.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns the slot of the lowest confirmed block."""
         return self.build_and_send_request("getFirstAvailableBlock", [None])
 
     def get_genesis_hash(self) -> RPCResponse[str] | str:
-        """
-        Returns the genesis hash.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns the genesis hash."""
         return self.build_and_send_request("getGenesisHash", [None])
 
     def get_health(self) -> RPCResponse[Literal["ok"]] | Literal["ok"]:
-        """
-        Returns the health.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns the current health of the node."""
         return self.build_and_send_request("getHealth", [None])
 
     def get_identity(self) -> RPCResponse[PubKeyIdentityType] | PubKeyIdentity:
-        """
-        Returns the identity.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns the identity pubkey of the current node."""
         response = self.build_and_send_request("getIdentity", [None])
         if self.clean_response:
             return PubKeyIdentity(response)
         return response
 
+    def get_version(self) -> RPCResponse[Dict[str, Any]] | Dict[str, Any]:
+        """Returns the current Solana version running on the node."""
+        return self.build_and_send_request("getVersion", [None])
+
+    def get_highest_snapshot_slot(self) -> RPCResponse[Dict[str, Any]] | Dict[str, Any]:
+        """Returns the highest slot info that the node has snapshots for."""
+        return self.build_and_send_request("getHighestSnapshotSlot", [None])
+
+    def get_leader_schedule(
+        self, slot: Optional[int] = None, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[Dict[str, List[int]]] | Dict[str, List[int]]:
+        """Returns the leader schedule for an epoch."""
+        params: list = [slot]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return self.build_and_send_request("getLeaderSchedule", params)
+
+    def get_max_retransmit_slot(self) -> RPCResponse[int] | int:
+        """Returns the max slot seen from retransmit stage."""
+        return self.build_and_send_request("getMaxRetransmitSlot", [None])
+
+    def get_max_shred_insert_slot(self) -> RPCResponse[int] | int:
+        """Returns the max slot seen from after shred insert."""
+        return self.build_and_send_request("getMaxShredInsertSlot", [None])
+
+    def get_slot(self, commitment: Optional[Commitment] = None) -> RPCResponse[int] | int:
+        """Returns the current slot."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return self.build_and_send_request("getSlot", params if params else [None])
+
+    def get_slot_leader(self, commitment: Optional[Commitment] = None) -> RPCResponse[str] | str:
+        """Returns the current slot leader."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return self.build_and_send_request("getSlotLeader", params if params else [None])
+
+    def get_slot_leaders(
+        self, start_slot: int, limit: int
+    ) -> RPCResponse[List[str]] | List[str]:
+        """Returns the slot leaders for a given slot range."""
+        return self.build_and_send_request("getSlotLeaders", [start_slot, limit])
+
+    def minimum_ledger_slot(self) -> RPCResponse[int] | int:
+        """Returns the lowest slot that the node has info about in its ledger."""
+        return self.build_and_send_request("minimumLedgerSlot", [None])
+
+    def get_vote_accounts(
+        self, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[Dict[str, Any]] | Dict[str, Any]:
+        """Returns the account info and associated stake for all voting accounts."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return self.build_and_send_request("getVoteAccounts", params if params else [None])
+
+    # ========================================================================
+    # Fee Methods
+    # ========================================================================
+
+    def get_fee_for_message(
+        self, message: Text, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[int] | int:
+        """Returns the fee for a given message (base64-encoded)."""
+        params: list = [message]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getFeeForMessage", params)
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    def get_recent_prioritization_fees(
+        self, addresses: Optional[List[Text]] = None
+    ) -> RPCResponse[List[Dict[str, Any]]] | List[Dict[str, Any]]:
+        """Returns recent prioritization fees from recent blocks."""
+        params: list = []
+        if addresses:
+            params.append(addresses)
+        return self.build_and_send_request("getRecentPrioritizationFees", params if params else [None])
+
+    # ========================================================================
+    # Inflation Methods
+    # ========================================================================
+
     def get_inflation_governor(
         self, commitment: Optional[Commitment] = None
     ) -> RPCResponse[InflationGovernorType] | InflationGovernor:
-        """
-        Returns the inflation governor.
-
-        Args:
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request("getInflationGovernor", [commitment])
+        """Returns the current inflation governor."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getInflationGovernor", params if params else [None])
         if self.clean_response:
             return InflationGovernor(response)
         return response
 
     def get_inflation_rate(self) -> RPCResponse[InflationRateType] | InflationRate:
-        """
-        Returns the inflation rate.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns the specific inflation values for the current epoch."""
         response = self.build_and_send_request("getInflationRate", [None])
         if self.clean_response:
             return InflationRate(response)
         return response
 
     def get_inflation_reward(
-        self, addresses: List[Text], commitment: Optional[Commitment] = None
+        self, addresses: List[Text], commitment: Optional[Commitment] = None,
+        epoch: Optional[int] = None
     ) -> RPCResponse[List[InflationRewardType]] | List[InflationReward]:
-        """
-        Returns the inflation reward for the specified addresses.
-
-        Args:
-            addresses (List[str]): The addresses.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        addresses.append(commitment)
-        response = self.build_and_send_request("getInflationReward", addresses)
+        """Returns the inflation / staking reward for a list of addresses."""
+        params: list = [addresses]
+        config: Dict[str, Any] = {}
+        if commitment:
+            config.update(validate_commitment(commitment))
+        if epoch is not None:
+            config["epoch"] = epoch
+        if config:
+            params.append(config)
+        response = self.build_and_send_request("getInflationReward", params)
         if self.clean_response:
-            return [InflationReward(reward) for reward in response]
+            return [InflationReward(reward) for reward in response if reward]
         return response
 
-    def get_largest_accounts(
-        self,
-    ) -> RPCResponse[List[LargestAccountsType]] | List[LargestAccounts]:
-        """
-        Returns the largest accounts.
+    # ========================================================================
+    # Supply Methods
+    # ========================================================================
 
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        response = self.build_and_send_request("getLargestAccounts", [None])
-        if self.clean_response:
-            return [LargestAccounts(account) for account in response["value"]]
-        return response
-
-    def get_leader_schedule(
-        self,
-    ) -> (
-        RPCResponse[Dict[str, Union[List[int], Any]]] | Dict[str, Union[List[int], Any]]
-    ):
-        """
-        Returns the leader schedule.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        return self.build_and_send_request("getLeaderSchedule", [None])
-
-    def get_max_retransmit_slot(self) -> RPCResponse[int] | int:
-        """
-        Returns the maximum retransmit slot.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        return self.build_and_send_request("getMaxRetransmitSlot", [None])
-
-    def get_max_shred_insert_slot(self) -> RPCResponse[int] | int:
-        """
-        Returns the maximum shred insert slot.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        return self.build_and_send_request("getMaxShredInsertSlot", [None])
-
-    def get_minimum_balance_for_rent_exemption(
-        self, acct_length: int, commitment: Optional[Commitment] = None
-    ) -> RPCResponse[int] | int:
-        """
-        Returns the minimum balance for rent exemption.
-
-        Args:
-            acct_length (int): The length of the account.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        return self.build_and_send_request(
-            "getMinimumBalanceForRentExemption", [acct_length, commitment]
-        )
-
-    def get_multiple_accounts(
-        self, pubkeys: List[str]
-    ) -> RPCResponse[List[AccountInfoType]] | List[AccountInfo]:
-        """
-        Returns the multiple accounts.
-
-        Args:
-            pubkeys (list): The public keys.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        response = self.build_and_send_request("getMultipleAccounts", pubkeys)
-        if self.clean_response:
-            return [AccountInfo(account) for account in response["value"]]
-        return response
-
-    def get_program_accounts(
-        self, public_key: PublicKey
-    ) -> RPCResponse[List[ProgramAccountType]] | List[ProgramAccount]:
-        """
-        Returns the program accounts.
-
-        Args:
-            public_key (PublicKey): The public key.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        response = self.build_and_send_request("getProgramAccounts", [public_key])
-        if self.clean_response:
-            return [ProgramAccount(account) for account in response]
-        return response
-
-    def get_latest_blockhash(
+    def get_supply(
         self, commitment: Optional[Commitment] = None
-    ) -> RPCResponse[BlockHashType] | BlockHash:
-        """
-        Returns the recent blockhash.
-
-        Args:
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request("getLatestBlockhash", [commitment])
-        if self.clean_response:
-            return BlockHash(response["value"])
-        return response
-
-    def get_recent_performance_samples(
-        self, commitment: Optional[Commitment] = None
-    ) -> (
-        RPCResponse[List[RecentPerformanceSamplesType]] | List[RecentPerformanceSamples]
-    ):
-        """
-        Returns the recent performance samples.
-
-        Args:
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request(
-            "getRecentPerformanceSamples", [commitment]
-        )
-        if self.clean_response:
-            return [RecentPerformanceSamples(sample) for sample in response]
-        return response
-
-    def get_signatures_for_address(
-        self,
-        acct_address: Text,
-        limit: Optional[Text] = None,
-        before: Optional[Text] = None,
-        until: Optional[Text] = None,
-    ) -> RPCResponse[List[TransactionSignatureType]] | List[TransactionSignature]:
-        """
-        Returns the signatures for the specified account address.
-
-        Args:
-            acct_address (str): The account address.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        params = [acct_address]
-        options = {}
-
-        if limit is not None:
-            options["limit"] = limit
-        if before is not None:
-            options["before"] = before
-        if until is not None:
-            options["until"] = until
-
-        if options:
-            params.append(options)
-
-        response = self.build_and_send_request("getSignaturesForAddress", params)
-        if self.clean_response:
-            return [TransactionSignature(signature) for signature in response]
-        return response
-
-    def get_signature_statuses(
-        self, transaction_sigs: List[Text]
-    ) -> RPCResponse[List[SignatureStatusType]] | List[SignatureStatus]:
-        """
-        Returns the signature statuses for the specified transaction signatures.
-
-        Args:
-            transaction_sigs (List[str]): The transaction signatures.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        response = self.build_and_send_request("getSignatureStatuses", transaction_sigs)
-        if self.clean_response:
-            return [SignatureStatus(status) for status in response["value"]]
-        return response
-
-    def get_slot(self) -> RPCResponse[int] | int:
-        """
-        Returns the current slot.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        return self.build_and_send_request("getSlot", [None])
-
-    def get_supply(self) -> RPCResponse[SupplyType] | Supply:
-        """
-        Returns the supply.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-        response = self.build_and_send_request("getSupply", [None])
+    ) -> RPCResponse[SupplyType] | Supply:
+        """Returns information about the current supply."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getSupply", params if params else [None])
         if self.clean_response:
             return Supply(response["value"])
         return response
 
+    # ========================================================================
+    # Stake Methods
+    # ========================================================================
+
+    def get_stake_minimum_delegation(
+        self, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[int] | int:
+        """Returns the stake minimum delegation in lamports."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getStakeMinimumDelegation", params if params else [None])
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    # ========================================================================
+    # Token Methods
+    # ========================================================================
+
     def get_token_accounts_by_owner(
-        self,
-        public_key: Text | PublicKey,
-        commitment: Optional[Commitment] = None,
+        self, public_key: Text | PublicKey, commitment: Optional[Commitment] = None,
         **kwargs,
     ) -> RPCResponse[List[ProgramAccountType]] | List[ProgramAccount]:
-        """
-        Returns the token accounts for the specified owner.
-
-        Args:
-            public_key (str | PublicKey): The public key of the owner.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-            **kwargs: Additional keyword arguments.
-
-        Raises:
-            ValueError: If neither mint_id nor program_id is passed as a keyword argument.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
+        """Returns all SPL Token accounts by owner."""
         if "mint_id" not in kwargs and "program_id" not in kwargs:
-            raise ValueError(
-                "You must pass either mint_id or program_id keyword argument"
-            )
+            raise ValueError("You must pass either mint_id or program_id keyword argument")
         mint_id = kwargs.get("mint_id")
         program_id = kwargs.get("program_id")
-        # Who doesn't like JSON?
         encoding = kwargs.get("encoding", "jsonParsed")
 
-        commitment = validate_commitment(commitment) if commitment else None
+        config: Dict[str, Any] = {"encoding": encoding}
+        if commitment:
+            config.update(validate_commitment(commitment))
+
         response = self.build_and_send_request(
             "getTokenAccountsByOwner",
-            [
-                str(public_key),
-                {"mint": mint_id} if mint_id else {"programId": program_id},
-                {"encoding": encoding, "commitment": commitment},
-            ],
+            [str(public_key), {"mint": mint_id} if mint_id else {"programId": program_id}, config],
+        )
+        if self.clean_response:
+            return [ProgramAccount(account) for account in response["value"]]
+        return response
+
+    def get_token_accounts_by_delegate(
+        self, delegate: Text | PublicKey, commitment: Optional[Commitment] = None,
+        **kwargs,
+    ) -> RPCResponse[List[ProgramAccountType]] | List[ProgramAccount]:
+        """Returns all SPL Token accounts approved by a delegate."""
+        if "mint_id" not in kwargs and "program_id" not in kwargs:
+            raise ValueError("You must pass either mint_id or program_id keyword argument")
+        mint_id = kwargs.get("mint_id")
+        program_id = kwargs.get("program_id")
+        encoding = kwargs.get("encoding", "jsonParsed")
+
+        config: Dict[str, Any] = {"encoding": encoding}
+        if commitment:
+            config.update(validate_commitment(commitment))
+
+        response = self.build_and_send_request(
+            "getTokenAccountsByDelegate",
+            [str(delegate), {"mint": mint_id} if mint_id else {"programId": program_id}, config],
         )
         if self.clean_response:
             return [ProgramAccount(account) for account in response["value"]]
         return response
 
     def get_token_account_balance(
-        self,
-        token_account: Text | PublicKey,
-        commitment: Optional[Commitment] = None,
+        self, token_account: Text | PublicKey, commitment: Optional[Commitment] = None,
     ) -> RPCResponse:
-        """
-        Returns the token account balance for the specified owner.
-
-        Args:
-            token_account (str | PublicKey): The token account pubkey.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-
-        Returns:
-            RPCResponse: The response from the RPC endpoint.
-        """
-
-        commitment = validate_commitment(commitment) if commitment else None
-        response = self.build_and_send_request(
-            "getTokenAccountBalance",
-            [
-                str(token_account),
-            ],
-        )
+        """Returns the token balance of an SPL Token account."""
+        params: list = [str(token_account)]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getTokenAccountBalance", params)
         if self.clean_response:
             return response["value"]
         return response
 
+    def get_token_supply(
+        self, mint: Text | PublicKey, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[Dict[str, Any]] | Dict[str, Any]:
+        """Returns the total supply of an SPL Token."""
+        params: list = [str(mint)]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getTokenSupply", params)
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    def get_token_largest_accounts(
+        self, mint: Text | PublicKey, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[List[Dict[str, Any]]] | List[Dict[str, Any]]:
+        """Returns the 20 largest accounts for an SPL Token."""
+        params: list = [str(mint)]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        response = self.build_and_send_request("getTokenLargestAccounts", params)
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    # ========================================================================
+    # Transaction Methods
+    # ========================================================================
+
     def get_transaction(
-        self,
-        signature: Text,
+        self, signature: Text,
         max_supported_transaction_version: Optional[int] = 0,
         commitment: Optional[Commitment] = None,
     ) -> RPCResponse[TransactionElementType] | TransactionElement:
-        """
-        Sends a request to the Solana RPC endpoint to retrieve a transaction by its signature.
-
-        Args:
-            signature (str): The signature of the transaction to retrieve.
-            commitment (Commitment, optional): The level of commitment desired when querying state.
-            max_supported_transaction_version (int, optional): Set the max transaction version to return in responses
-
-        Returns:
-            RPCResponse: The response from the Solana RPC endpoint.
-        """
-        response = self.build_and_send_request(
-            "getTransaction",
-            [
-                signature,
-                {
-                    "commitment": commitment,
-                    "maxSupportedTransactionVersion": max_supported_transaction_version,
-                },
-            ],
-        )
+        """Returns transaction details for a confirmed transaction."""
+        config: Dict[str, Any] = {
+            "maxSupportedTransactionVersion": max_supported_transaction_version,
+        }
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = self.build_and_send_request("getTransaction", [signature, config])
         if self.clean_response:
-            if response == None:
+            if response is None:
                 raise ValueError("Transaction not found")
             return TransactionElement(response)
         return response
 
-    def build_and_send_request(
-        self, method, params: List[Any]
-    ) -> RPCResponse | Dict[str, Any] | List[Dict[str, Any]]:
-        """
-        Builds and sends an RPC request to the server.
+    def get_transaction_count(
+        self, commitment: Optional[Commitment] = None
+    ) -> RPCResponse[int] | int:
+        """Returns the current transaction count from the ledger."""
+        params: list = []
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return self.build_and_send_request("getTransactionCount", params if params else [None])
 
-        Args:
-            method (str): The RPC method to call.
-            params (List[Any]): The parameters to pass to the RPC method.
-
-        Returns:
-            RPCResponse: The response from the server.
-        """
-        data: Dict[str, Any] = self.http.build_data(method=method, params=params)
-        res: RPCResponse = self.http.send(data)
+    def get_signatures_for_address(
+        self, acct_address: Text,
+        limit: Optional[int] = None,
+        before: Optional[Text] = None,
+        until: Optional[Text] = None,
+        commitment: Optional[Commitment] = None,
+    ) -> RPCResponse[List[TransactionSignatureType]] | List[TransactionSignature]:
+        """Returns signatures for confirmed transactions involving an address."""
+        params: list = [acct_address]
+        options: Dict[str, Any] = {}
+        if limit is not None:
+            options["limit"] = limit
+        if before is not None:
+            options["before"] = before
+        if until is not None:
+            options["until"] = until
+        if commitment:
+            options.update(validate_commitment(commitment))
+        if options:
+            params.append(options)
+        response = self.build_and_send_request("getSignaturesForAddress", params)
         if self.clean_response:
-            if "error" in res:
-                raise RPCRequestError(
-                    f"Failed to fetch data from RPC endpoint. Error {res['error']['code']}: {res['error']['message']}"
-                )
+            return [TransactionSignature(sig) for sig in response]
+        return response
 
-            if (
-                isinstance(res["result"], dict)
-                or isinstance(res["result"], list)
-                or isinstance(res["result"], str)
-                or isinstance(res["result"], int)
-                or res["result"] == None
-            ):
-                return res["result"]
-            else:
-                raise RPCRequestError(
-                    f"Invalid response from RPC endpoint. Expected types dict | list | str, got {type(res['result']).__name__}"
-                )
+    def get_signature_statuses(
+        self, transaction_sigs: List[Text], search_transaction_history: bool = False
+    ) -> RPCResponse[List[SignatureStatusType]] | List[SignatureStatus]:
+        """Returns the statuses of a list of signatures."""
+        params: list = [transaction_sigs]
+        if search_transaction_history:
+            params.append({"searchTransactionHistory": True})
+        response = self.build_and_send_request("getSignatureStatuses", params)
+        if self.clean_response:
+            return [SignatureStatus(status) for status in response["value"] if status]
+        return response
 
-        return res
+    def get_recent_performance_samples(
+        self, limit: Optional[int] = None
+    ) -> RPCResponse[List[RecentPerformanceSamplesType]] | List[RecentPerformanceSamples]:
+        """Returns a list of recent performance samples."""
+        params: list = [limit] if limit else [None]
+        response = self.build_and_send_request("getRecentPerformanceSamples", params)
+        if self.clean_response:
+            return [RecentPerformanceSamples(sample) for sample in response]
+        return response
 
-    # Non "get" methods
+    def simulate_transaction(
+        self, transaction: Text,
+        sig_verify: bool = False,
+        commitment: Optional[Commitment] = None,
+        replace_recent_blockhash: bool = False,
+    ) -> RPCResponse[Dict[str, Any]] | Dict[str, Any]:
+        """Simulates sending a transaction (base64-encoded)."""
+        config: Dict[str, Any] = {
+            "encoding": "base64",
+            "sigVerify": sig_verify,
+            "replaceRecentBlockhash": replace_recent_blockhash,
+        }
+        if commitment:
+            config.update(validate_commitment(commitment))
+        response = self.build_and_send_request("simulateTransaction", [transaction, config])
+        if self.clean_response:
+            return response["value"]
+        return response
+
+    # ========================================================================
+    # Action Methods (non-get)
+    # ========================================================================
+
     def request_airdrop(
-        self, public_key: PublicKey | Text, lamports: int
+        self, public_key: PublicKey | Text, lamports: int,
+        commitment: Optional[Commitment] = None
     ) -> RPCResponse[str] | str:
-        """
-        Requests an airdrop of lamports to the specified public key.
+        """Requests an airdrop of lamports to the specified public key."""
+        params: list = [str(public_key), lamports]
+        if commitment:
+            params.append(validate_commitment(commitment))
+        return self.build_and_send_request("requestAirdrop", params)
 
-        Args:
-            public_key (PublicKey | Text): The public key of the account to receive the airdrop.
-            lamports (int): The amount of lamports to request in the airdrop.
-
-        Returns:
-            RPCResponse: The response from the Solana JSON RPC API.
-        """
-        return self.build_and_send_request("requestAirdrop", [public_key, lamports])
-
-    def send_transaction(self, transaction: Transaction, options: Optional[Dict] = None) -> RPCResponse[str] | str:
-        """
-        Sends a transaction to the Solana network.
-
-        Args:
-            transaction (Transaction): The transaction to send.
-            options (Dict): Options for sending transactions
-
-        Returns:
-            RPCResponse: The response from the Solana network.
-        """
+    def send_transaction(
+        self, transaction: Transaction, options: Optional[Dict] = None
+    ) -> RPCResponse[str] | str:
+        """Signs and sends a transaction to the network."""
         recent_blockhash = transaction.recent_blockhash
-
         if recent_blockhash is None:
             blockhash_resp = self.get_latest_blockhash()
             recent_blockhash = blockhash_resp.blockhash
-        
-        if options:
-            options = options
-        else:
+
+        if options is None:
             options = {"encoding": "base64"}
 
         transaction.recent_blockhash = recent_blockhash
@@ -793,3 +666,27 @@ class Client:
         return self.build_and_send_request(
             "sendTransaction", [transaction.serialize(), options]
         )
+
+    # ========================================================================
+    # Internal
+    # ========================================================================
+
+    def build_and_send_request(
+        self, method: str, params: List[Any]
+    ) -> RPCResponse | Dict[str, Any] | List[Dict[str, Any]]:
+        """Builds and sends an RPC request."""
+        data: Dict[str, Any] = self.http.build_data(method=method, params=params)
+        res: RPCResponse = self.http.send(data)
+        if self.clean_response:
+            if "error" in res:
+                raise RPCRequestError(
+                    f"RPC Error {res['error']['code']}: {res['error']['message']}"
+                )
+            result = res.get("result")
+            if result is None or isinstance(result, (dict, list, str, int, float, bool)):
+                return result
+            else:
+                raise RPCRequestError(
+                    f"Unexpected response type: {type(result).__name__}"
+                )
+        return res

--- a/solathon/core/http.py
+++ b/solathon/core/http.py
@@ -25,11 +25,16 @@ class HTTPClient:
             ),
         }
         self.request_id = 0
-        self.client = httpx.Client()
+        self.client = httpx.Client(timeout=30.0)
 
     def send(self, data: Dict[str, Any]) -> RPCResponse:
         res = self.client.post(
                 url=self.endpoint, headers=self.headers, json=data)
+        return res.json()
+
+    def send_batch(self, batch: list[Dict[str, Any]]) -> list[RPCResponse]:
+        res = self.client.post(
+                url=self.endpoint, headers=self.headers, json=batch)
         return res.json()
 
     def build_data(self, method: str, params: List[Any]) -> Dict[str, Any]:
@@ -58,7 +63,6 @@ class AsyncHTTPClient:
     """Asynchronous HTTP Client to interact with Solana JSON RPC"""
 
     def __init__(self, endpoint: str):
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         self.endpoint = endpoint
         version = sys.version_info
         self.headers = {
@@ -69,12 +73,16 @@ class AsyncHTTPClient:
             ),
         }
         self.request_id = 0
-        self.client = httpx.AsyncClient()
-        
+        self.client = httpx.AsyncClient(timeout=30.0)
 
     async def send(self, data: Dict[str, Any]) -> RPCResponse:
         res = await self.client.post(
                 url=self.endpoint, headers=self.headers, json=data)
+        return res.json()
+
+    async def send_batch(self, batch: list[Dict[str, Any]]) -> list[RPCResponse]:
+        res = await self.client.post(
+                url=self.endpoint, headers=self.headers, json=batch)
         return res.json()
 
     def build_data(self, method: str, params: List[Any]) -> Dict[str, Any]:

--- a/solathon/core/types/__init__.py
+++ b/solathon/core/types/__init__.py
@@ -38,8 +38,7 @@ class RPCResponse(TypedDict):
     result: Any
     error: RPCErrorType
 
-Commitment = Literal["processed", "confirmed", "finalized", "recent", "single", "singleGossip", "root", "max"]
-CommitmentConfig = Literal["processed", "confirmed", "finalized"]
+Commitment = Literal["processed", "confirmed", "finalized"]
 
 class PubKeyIdentityType(TypedDict):
     '''
@@ -100,7 +99,7 @@ class TransactionSignatureType(TypedDict):
     err: Any
     memo: Optional[str]
     blockTime: Optional[int]
-    confirmationStatus: Optional[CommitmentConfig]
+    confirmationStatus: Optional[Commitment]
 
 class TransactionSignature:
     '''
@@ -122,7 +121,7 @@ class SignatureStatusType(TypedDict):
     slot: int
     confirmations: Optional[int]
     err: Any
-    confirmationStatus: Optional[CommitmentConfig]
+    confirmationStatus: Optional[Commitment]
 
 class SignatureStatus:
     '''

--- a/solathon/publickey.py
+++ b/solathon/publickey.py
@@ -40,5 +40,8 @@ class PublicKey:
             return self.byte_value == __value.byte_value
         return False
 
+    def __hash__(self) -> int:
+        return hash(self.byte_value)
+
     def base58_encode(self) -> bytes:
         return base58.b58encode(bytes(self))

--- a/solathon/utils.py
+++ b/solathon/utils.py
@@ -24,16 +24,14 @@ def truncate_float(number: float, length: int) -> float:
     return number
 
 
-def validate_commitment(value: Commitment) -> Commitment:
-    # If the types change make the same change in the type hint
-    allowed_commitments = {"processed", "confirmed", "finalized",
-                           "recent", "single", "singleGossip", "root", "max"}
+def validate_commitment(value: Commitment) -> dict:
+    allowed_commitments = {"processed", "confirmed", "finalized"}
 
     if value not in allowed_commitments:
         raise ValueError(
             f"Invalid commitment value. Allowed values are {allowed_commitments}")
 
-    return value
+    return {"commitment": value}
 
 def lamport_to_sol(lamports: int) -> float:
     return truncate_float(lamports * SOL_PER_LAMPORT, SOL_FLOATING_PRECISION)


### PR DESCRIPTION
## What changed

### Breaking Changes
- Removed deprecated commitment values (`recent`, `single`, `singleGossip`, `root`, `max`) — only `processed`, `confirmed`, `finalized` are valid now (Agave v2.0)
- Endpoint validation relaxed — any HTTP/HTTPS URL accepted (supports Helius, QuickNode, Alchemy, Triton, etc.)

### 14 New RPC Methods
`get_token_supply`, `get_token_largest_accounts`, `get_token_accounts_by_delegate`, `get_highest_snapshot_slot`, `is_blockhash_valid`, `simulate_transaction`, `get_stake_minimum_delegation`, `get_recent_prioritization_fees`, `get_slot_leader`, `get_slot_leaders`, `get_transaction_count`, `get_version`, `get_vote_accounts`, `minimum_ledger_slot`

All available on both `Client` and `AsyncClient`.

### Bug Fixes
- Fix `get_inflation_reward` mutating input list
- Fix commitment param passing on `get_balance`, `get_block_height`, `get_block_production`, `get_account_info`
- Fix `get_multiple_accounts` wrong param structure (must wrap pubkeys in array)
- Fix `get_signature_statuses` wrong param structure
- Fix `AsyncHTTPClient` crashing on Linux/macOS (Windows-only event loop policy removed)
- Add `search_transaction_history` option to `get_signature_statuses`
- Add `filters` option to `get_program_accounts`

### Improvements
- `PublicKey` now hashable (usable in sets/dict keys)
- HTTP clients have 30s timeout + batch request support
- `AsyncClient` now has `clean_response` mode (parity with sync Client)
- README updated with complete RPC method reference table
- Version bumped to 1.1.0

### Tested
All new methods verified against live Solana devnet.