### PR TITLE
fix: check type of actual result in negative input tests

### DIFF
--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -41,7 +41,7 @@ def test_sol_to_lamport_none_passed_in():
 def test_sol_to_lamport_negative_input(arg, expected):
     actual = utils.sol_to_lamport(arg)
     assert actual == expected
-    assert isinstance(expected, int)
+    assert isinstance(actual, int)
 
 
 def test_sol_to_lamport_large_input():
@@ -65,7 +65,7 @@ def test_lamport_to_sol_none_passed_in():
 def test_lamport_to_sol_negative_input(arg, expected):
     actual = utils.lamport_to_sol(arg)
     assert actual == expected
-    assert isinstance(expected, float)
+    assert isinstance(actual, float)
 
 
 def test_lamport_to_sol_large_input():


### PR DESCRIPTION
Fixed a copy-paste error in the negative input tests where the type assertion checked expected instead of actual. The tests now correctly validate the return type of the functions. No library behavior changed, and all 28 tests continue to pass.